### PR TITLE
Include nano text editor

### DIFF
--- a/bk-config.sh
+++ b/bk-config.sh
@@ -26,6 +26,7 @@ apt-get update \
     libsqlite3-dev \
     libssl-dev \
     libudunits2-dev \
+    nano \
     netcdf-bin \
     postgis \
     protobuf-compiler \


### PR DESCRIPTION
nano might be needed when we teach git or shiny deployment.