### PR TITLE
Missing package prettydoc

### DIFF
--- a/bk-install.R
+++ b/bk-install.R
@@ -109,6 +109,7 @@ to_install <- unique(
       "pkgdown",
       "pkgload",
       "plotly",
+      "prettydoc",
       "proto",
       "proustr",
       "pryr",


### PR DESCRIPTION
tags: fix

Why?

- Missing package {prettydoc} [N1]

What?

- Add prettydoc in bk_install.R

Issues
fix issue #8